### PR TITLE
Fixes warning about range syntax

### DIFF
--- a/lib/elixlsx/color.ex
+++ b/lib/elixlsx/color.ex
@@ -19,7 +19,7 @@ defmodule Elixlsx.Color do
         "FF" <>
           (color
            # remove leading character
-           |> String.slice(1..-1)
+           |> String.slice(1..-1//1)
            |> String.upcase())
 
       false ->


### PR DESCRIPTION
Example of the warning:

```
warning: negative steps are not supported in String.slice/2, pass 1..-1//1 instead
  (elixir 1.16.0) lib/string.ex:2368: String.slice/2
  (elixlsx 0.5.2) lib/elixlsx/color.ex:22: Elixlsx.Color.to_rgb_color/1
  (elixlsx 0.5.2) lib/elixlsx/style/fill.ex:33: Elixlsx.Style.Fill.get_stylexml_entry/1
  (elixir 1.16.0) lib/enum.ex:1801: anonymous fn/2 in Enum.map_join/3
  (elixir 1.16.0) lib/enum.ex:4381: Enum.map_intersperse_list/3
  (elixir 1.16.0) lib/enum.ex:1801: Enum.map_join/3
  (elixlsx 0.5.2) lib/elixlsx/xml_templates.ex:752: Elixlsx.XMLTemplates.make_xl_styles/1
  (elixlsx 0.5.2) lib/elixlsx/writer.ex:86: Elixlsx.Writer.get_xl_styles_xml/1
  (elixlsx 0.5.2) lib/elixlsx/writer.ex:124: Elixlsx.Writer.get_xl_dir/2
  (elixlsx 0.5.2) lib/elixlsx/writer.ex:26: Elixlsx.Writer.create_files/2
  (elixlsx 0.5.2) lib/elixlsx.ex:61: Elixlsx.write_to_memory/2
```